### PR TITLE
ENH: Waits for pid to update when reloading

### DIFF
--- a/proxy/ha_proxy.go
+++ b/proxy/ha_proxy.go
@@ -174,11 +174,14 @@ func (m HaProxy) Reload() error {
 		} else {
 			cmdArgs = []string{reloadStrategy, string(pid)}
 		}
+
 		reloadErr = HaProxy{}.RunCmd(cmdArgs)
 		if reloadErr == nil {
+			waitForPidToUpdate(pid, pidPath)
 			logPrintf("Proxy config was reloaded")
 			break
 		}
+
 		logPrintf("Proxy config could not be reloaded. Will try again...")
 		time.Sleep(time.Millisecond * reloadPause)
 	}

--- a/proxy/ha_proxy_test.go
+++ b/proxy/ha_proxy_test.go
@@ -92,22 +92,29 @@ config2 be content`
 	os.Setenv("STATS_PASS_ENV", "STATS_PASS")
 	os.Setenv("STATS_URI_ENV", "STATS_URI")
 	os.Setenv("SERVICE_DOMAIN_ALGO", "hdr_beg(host)")
+
 	reloadPauseOrig := reloadPause
 	reconfigureAttemptsOrig := os.Getenv("RECONFIGURE_ATTEMPTS")
 	os.Setenv("RECONFIGURE_ATTEMPTS", "1")
 	cmdRunHaOrig := cmdRunHa
-	defer func() { cmdRunHa = cmdRunHaOrig }()
+	waitForPidToUpdateOrig := waitForPidToUpdate
+	defer func() {
+		cmdRunHa = cmdRunHaOrig
+		waitForPidToUpdate = waitForPidToUpdateOrig
+		reloadPause = reloadPauseOrig
+		os.Setenv("RECONFIGURE_ATTEMPTS", reconfigureAttemptsOrig)
+		os.Unsetenv("SERVICE_DOMAIN_ALGO")
+	}()
+
+	waitForPidToUpdate = func(previousPid []byte, pidPath string) {
+	}
+
 	cmdRunHa = func(args []string) error {
 		return nil
 	}
 	cmdValidateHa = func(args []string) error {
 		return nil
 	}
-	defer func() {
-		reloadPause = reloadPauseOrig
-		os.Setenv("RECONFIGURE_ATTEMPTS", reconfigureAttemptsOrig)
-		os.Unsetenv("SERVICE_DOMAIN_ALGO")
-	}()
 	reloadPause = 1
 	suite.Run(t, s)
 }

--- a/proxy/util.go
+++ b/proxy/util.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"sync"
 	"syscall"
+	"time"
 	"unicode"
 )
 
@@ -60,6 +61,17 @@ var cmdRunHa = func(args []string) error {
 var cmdValidateHa = func(args []string) error {
 	return cmdRunHa(args)
 }
+var waitForPidToUpdate = func(previousPid []byte, pidPath string) {
+	ticker := time.NewTicker(500 * time.Millisecond).C
+	for range ticker {
+		if currentPid, err := readPidFile(pidPath); err == nil {
+			if !bytes.Equal(previousPid, currentPid) {
+				return
+			}
+		}
+	}
+}
+
 var readConfigsFile = ioutil.ReadFile
 var readSecretsFile = ioutil.ReadFile
 var writeFile = ioutil.WriteFile

--- a/proxy/util_test.go
+++ b/proxy/util_test.go
@@ -3,6 +3,7 @@ package proxy
 import (
 	"os"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/suite"
 )
@@ -36,4 +37,42 @@ func (s *UtilTestSuite) Test_HaProxyCmd_ReturnsError_WhenStdErrIsNotEmpty() {
 	err := cmdRunHa([]string{"-j"}) // `-j` argument is invalid
 
 	s.Error(err)
+}
+
+func (s *UtilTestSuite) Test_WaitForPidToUpdate_WaitsForUpdate() {
+	readPidFileOrig := readPidFile
+	defer func() {
+		readPidFile = readPidFileOrig
+	}()
+
+	readPidFileCalledCnt := 0
+	readPidFile = func(filename string) ([]byte, error) {
+		readPidFileCalledCnt++
+		if readPidFileCalledCnt == 2 {
+			return []byte("102"), nil
+		}
+		return []byte("101"), nil
+	}
+
+	timer := time.NewTimer(2 * time.Second).C
+	done := make(chan struct{})
+
+	previousPid := []byte("101")
+
+	go func() {
+		waitForPidToUpdate(previousPid, "filename")
+		done <- struct{}{}
+	}()
+
+L:
+	for {
+		select {
+		case <-timer:
+			s.FailNow("Timeout")
+		case <-done:
+			break L
+		}
+	}
+
+	s.Equal(2, readPidFileCalledCnt)
 }


### PR DESCRIPTION
This PR may help with the multiple PID issue in https://github.com/docker-flow/docker-flow-proxy/issues/23. I will detail my reasoning here:

The user noticed the following processes before updating services:

```
/ # ps aux
PID   USER     TIME   COMMAND
    1 root       0:00 /sbin/tini -g -- docker-flow-proxy server
    5 root       0:00 docker-flow-proxy server
   19 root       0:00 ash
  120 root       0:01 haproxy -f /cfg/haproxy.cfg -D -p /var/run/haproxy.pid -x /var/run/haproxy.sock -sf 117 
  371 root       0:00 ps aux
```

And after an updating services:

```
 TIME   COMMAND
    1 root       0:00 /sbin/tini -g -- docker-flow-proxy server
    5 root       0:01 docker-flow-proxy server
   19 root       0:00 ash
  440 root       0:00 haproxy -f /cfg/haproxy.cfg -D -p /var/run/haproxy.pid -x /var/run/haproxy.sock -sf 120 
  448 root       0:00 haproxy -f /cfg/haproxy.cfg -D -p /var/run/haproxy.pid -x /var/run/haproxy.sock -sf 120 
  690 root       0:00 haproxy -f /cfg/haproxy.cfg -D -p /var/run/haproxy.pid -x /var/run/haproxy.sock -sf 680 
  705 root       0:00 ps aux
```

In the before case, the haproxy is running on PID 120. Afterwards, there are two new processes that tries to send the `SIGUSR1` signal to PID 120. There should never be two processes trying to cancel the same process. This is mostly likely caused by DFP haproxy reloading not waiting for the old process to stop before processing another reload. 


My fix forces DFP haproxy reloading to wait for `/var/run/haproxy.pid` to update to a new PID before continuing.