### PR TITLE
ENH: Checks DFSL in healthcheck

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,7 @@ EXPOSE 8080
 RUN apk --no-cache add tini
 ENTRYPOINT ["/sbin/tini", "-g", "--"]
 CMD ["docker-flow-proxy", "server"]
-HEALTHCHECK --interval=5s --start-period=3s --timeout=5s CMD check.sh
+HEALTHCHECK --interval=5s --start-period=3s --timeout=10s CMD check.sh
 
 COPY scripts/check.sh /usr/local/bin/check.sh
 RUN chmod +x /usr/local/bin/check.sh

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -1,17 +1,33 @@
-if [[ "$HEALTHCHECK" = "true" ]] ; then
+if [[ "$HEALTHCHECK" == "true" ]]; then
 
     wget -qO- "http://localhost:8080/v1/docker-flow-proxy/ping"
 
-    if [[ $? -ne 0 ]] ; then
+    if [[ $? -ne 0 ]]; then
         echo "ERROR: Failed to ping docker-flow-proxy"
         exit 1
     fi
 
     pgrep -x "haproxy"
 
-    if [[ $? -ne 0 ]] ; then
+    if [[ $? -ne 0 ]]; then
         echo "ERROR: haproxy process is not running"
         exit 1
+    fi
+
+    if [[ "$LISTENER_ADDRESS" != "" ]]; then
+        wget -qO- "http://${LISTENER_ADDRESS}:8080/v1/docker-flow-swarm-listener/ping"
+
+        if [[ $? -ne 0 ]]; then
+            echo "ERROR: Unable to ping ${LISTENER_ADDRESS}"
+            exit 1
+        fi
+
+        wget -qO- "http://localhost:8080/v1/docker-flow-proxy/reload"
+
+        if [[ $? -ne 0 ]]; then
+            echo "ERROR: Unable to reload docker flow proxy"
+            exit 1
+        fi
     fi
 
 fi


### PR DESCRIPTION
Addresses #28. When `LISTENER_ADDRESS` is set, DFP adds the following to its healthcheck:

1. Ping DFSL.
2. Reload DFP, which will fetch services from DFSL and reconfigure DFP's haproxy.